### PR TITLE
feat: add stat cards to admin dashboard

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,7 +26,7 @@ function App() {
     <Router>
       <Navbar />
       <Routes>
-        <Route path="/" element={<Home />} />
+        {<Route path="/" element={<Home />} />}
 
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -1,9 +1,52 @@
 import { Link } from "react-router-dom";
+import { useEffect, useState } from "react"; 
+import api from "../api/api";
+
+// A small component for our statistics cards
+const StatCard = ({ title, value, bgColor }) => (
+  <div className={`card p-6 ${bgColor} text-white`}>
+    <h3 className="text-4xl font-bold">{value}</h3>
+    <p className="text-lg">{title}</p>
+  </div>
+);
 
 export default function AdminDashboard() {
+  const [stats, setStats] = useState({ users: 0, notes: 0, quizzes: 0});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const usersRes = await api.get("/users");
+        const notesRes = await api.get("/notes");
+        const quizzesRes = await api.get("/quizzes");
+
+        setStats({
+          users: usersRes.data.length,
+          notes: notesRes.data.length,
+          quizzes: quizzesRes.data.length,
+        });
+      } catch (error) {
+        console.error("Failed to fetch stats:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchStats();
+  }, []);
+
   return (
     <div className="max-w-4xl mx-auto mt-10 p-6">
       <h1 className="text-3xl font-bold mb-6">Admin Dashboard</h1>
+
+      {/* --- STATS CARDS SECTION --- */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10">
+        <StatCard title="Total Users" value={loading ? "..." : stats.users} bgColor="bg-blue-500" />
+        <StatCard title="Total Notes" value={loading ? "..." : stats.notes} bgColor="bg-green-500" />
+        <StatCard title="Total Quizzes" value={loading ? "..." : stats.quizzes} bgColor="bg-indigo-500" />
+      </div>
+      {/* --- END OF STATS CARDS --- */}
       
       <div className="mb-8 p-4 bg-gray-50 rounded border">
         <h2 className="text-xl font-semibold mb-2">Admin Features</h2>
@@ -38,3 +81,4 @@ export default function AdminDashboard() {
     </div>
   );
 }
+


### PR DESCRIPTION
@offsusangautam, this PR adds the UI for the new statistic cards on the admin dashboard. I've built the frontend components for the cards and added the `useEffect` logic to fetch the data. The API calls in `AdminDashboard.jsx` are in place, but they will need corresponding backend endpoints to be created to function correctly.